### PR TITLE
Undownloadable format warnings and faster thumbnail streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The archive format itself is simple and consists of a directory-based structure 
   - `yark.json` – Archive file with all metadata
   - `yark.bak` – Backup archive file to protect against data damage
   - `videos/` – Directory containing all known videos
-    - `[id].mp4` – Files containing video data for YouTube videos
+    - `[id].*` – Files containing video data for YouTube videos
   - `thumbnails/` – Directory containing all known thumbnails
     - `[hash].png` – Files containing thumbnails with its BLAKE2 hash
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Yark lets you continuously archive all videos and metadata for YouTube channels.
 
 ## Installation
 
-To install Yark, simply download Python 3.9+ and run the following:
+To install Yark, simply download [Python 3.9+](https://www.python.org/downloads/) and [FFmpeg](https://ffmpeg.org/) (optional), then run the following:
 
 ```shell
 $ pip3 install yark

--- a/yark/channel.py
+++ b/yark/channel.py
@@ -33,12 +33,20 @@ from typing import Optional
 
 
 class DownloadConfig:
+    max_videos: Optional[int]
+    max_livestreams: Optional[int]
+    max_shorts: Optional[int]
+    skip_download: bool
+    skip_metadata: bool
+    format: Optional[str]
+
     def __init__(self) -> None:
-        self.max_videos: Optional[int] = None
-        self.max_livestreams: Optional[int] = None
-        self.max_shorts: Optional[int] = None
-        self.skip_download: bool = False
-        self.skip_metadata: bool = False
+        self.max_videos = None
+        self.max_livestreams = None
+        self.max_shorts = None
+        self.skip_download = False
+        self.skip_metadata = False
+        self.format = None
 
     def submit(self):
         """Submits configuration, this has the effect of normalising maximums to 0 properly"""
@@ -235,14 +243,13 @@ class Channel:
         settings = {
             # Set the output path
             "outtmpl": f"{self.path}/videos/%(id)s.%(ext)s",
-            # Ask for this format
-            # NOTE: being replaced soon
-            "format": "best/mp4/hasvid",
             # Centralized logger hook for ignoring all stdout
             "logger": VideoLogger(),
             # Logger hook for download progress
             "progress_hooks": [VideoLogger.downloading],
         }
+        if config.format is not None:
+            settings["format"] = config.format
 
         # Attach to the downloader
         with YoutubeDL(settings) as ydl:

--- a/yark/channel.py
+++ b/yark/channel.py
@@ -316,16 +316,6 @@ class Channel:
                             else:
                                 raise exception
 
-                    # Set the extension of each video depending on what's been downloaded
-                    not_parts = [
-                        file
-                        for file in Path(self.path / "videos").iterdir()
-                        if file.suffix != ".part"
-                    ]
-                    for file in not_parts:
-                        video = self.search(file.stem)
-                        video.ext = file.suffix
-
                     # Stop if we've got them all
                     break
 

--- a/yark/cli.py
+++ b/yark/cli.py
@@ -63,8 +63,9 @@ def _cli():
     elif args[0] == "refresh":
         # More help
         if len(args) == 2 and args[1] == "--help":
+            # NOTE: if these get more complex, separate into something like "basic config" and "advanced config"
             print(
-                f"yark refresh [name] [args?]\n\n  Refreshes/downloads archive with optional configuration.\n  If a maximum is set, unset categories won't be downloaded\n\nArguments:\n  --videos=[max]        Maximum recent videos to download\n  --shorts=[max]        Maximum recent shorts to download\n  --livestreams=[max]   Maximum recent livestreams to download\n  --skip-metadata       Skips downloading metadata\n  --skip-download       Skips downloading content\n\n Example:\n  $ yark refresh demo\n  $ yark refresh demo --videos=5\n  $ yark refresh demo --shorts=2 --livestreams=25\n  $ yark refresh demo --skip-download"
+                f"yark refresh [name] [args?]\n\n  Refreshes/downloads archive with optional configuration.\n  If a maximum is set, unset categories won't be downloaded\n\nArguments:\n  --videos=[max]        Maximum recent videos to download\n  --shorts=[max]        Maximum recent shorts to download\n  --livestreams=[max]   Maximum recent livestreams to download\n  --skip-metadata       Skips downloading metadata\n  --skip-download       Skips downloading content\n  --format=[str]        Downloads using custom yt-dlp format for advanced users\n\n Example:\n  $ yark refresh demo\n  $ yark refresh demo --videos=5\n  $ yark refresh demo --shorts=2 --livestreams=25\n  $ yark refresh demo --skip-download"
             )
             sys.exit(0)
 
@@ -77,9 +78,12 @@ def _cli():
         config = DownloadConfig()
         if len(args) > 2:
 
+            def parse_value(config_arg: str) -> str:
+                return config_arg.split("=")[1]
+
             def parse_maximum_int(config_arg: str) -> int:
                 """Tries to parse a maximum integer input"""
-                maximum = config_arg.split("=")[1]
+                maximum = parse_value(config_arg)
                 try:
                     return int(maximum)
                 except:
@@ -110,6 +114,10 @@ def _cli():
                 # No downloading; functionally equivalent to all maximums being 0 but it skips entirely
                 elif config_arg == "--skip-download":
                     config.skip_download = True
+
+                # Custom yt-dlp format
+                elif config_arg.startswith("--format="):
+                    config.format = parse_value(config_arg)
 
                 # Unknown argument
                 else:

--- a/yark/templates/channel.html
+++ b/yark/templates/channel.html
@@ -71,11 +71,11 @@
 {% if channel.videos %}
 <div id="content">
     {% for video in channel.videos %}
-    <a href="/channel/{{ name }}/videos/{{ video.id }}" class="video">
+    <a href="{{ url_for('routes.video', name=name, kind='videos', id=video.id) }}" class="video">
         <!-- Thumbnail -->
         <div class="thumbnail">
-            <img src="/archive/{{ video.thumbnail.current().path }}" {% if not video.downloaded(ldir) %}class="frost" {%
-                endif %} />
+            <img src="{{ url_for('routes.archive_thumbnail', name=name, id=video.thumbnail.current().id) }}" {% if not
+                video.downloaded() %}class="frost" {% endif %} />
         </div>
         <!-- Information -->
         <div class="info">

--- a/yark/templates/video.html
+++ b/yark/templates/video.html
@@ -164,7 +164,8 @@
 {% block content %}
 <div id="content">
     <!-- Video -->
-    <video src="/archive/{{ video.channel.path }}/videos/{{ video.id }}.mp4" id="player" autoplay controls></video>
+    <video src="{{ url_for('routes.archive_video', name=name, file=video.id + '.mp4') }}" id="player" autoplay
+        controls></video>
     <!-- Information -->
     <h1 title="Title of the video">{{ video.title.current() }}</h1>
     <div class="info">
@@ -186,8 +187,8 @@
             <a title="Open the video on YouTube" href="https://www.youtube.com/watch?v={{ video.id }}">🔗</a>
             <!-- Download link -->
             <span class="spacer">•</span>
-            <a title="Save the video to downloads" href="/archive/{{ video.channel.path }}/videos/{{ video.id }}.mp4"
-                download>💾</a>
+            <a title="Save the video to downloads"
+                href="{{ url_for('routes.archive_video', name=name, file=video.id + '.mp4') }}" download>💾</a>
             <!-- Like count -->
             {% set likes = video.likes.current() %}
             {% if likes or likes == 0 %}

--- a/yark/templates/video.html
+++ b/yark/templates/video.html
@@ -164,7 +164,7 @@
 {% block content %}
 <div id="content">
     <!-- Video -->
-    <video src="{{ url_for('routes.archive_video', name=name, file=video.id + '.mp4') }}" id="player" autoplay
+    <video src="{{ url_for('routes.archive_video', name=name, file=video.filename()) }}" id="player" autoplay
         controls></video>
     <!-- Information -->
     <h1 title="Title of the video">{{ video.title.current() }}</h1>
@@ -188,7 +188,7 @@
             <!-- Download link -->
             <span class="spacer">•</span>
             <a title="Save the video to downloads"
-                href="{{ url_for('routes.archive_video', name=name, file=video.id + '.mp4') }}" download>💾</a>
+                href="{{ url_for('routes.archive_video', name=name, file=video.filename()) }}" download>💾</a>
             <!-- Like count -->
             {% set likes = video.likes.current() %}
             {% if likes or likes == 0 %}

--- a/yark/video.py
+++ b/yark/video.py
@@ -21,6 +21,7 @@ class Video:
     uploaded: datetime
     width: int
     height: int
+    ext: str
     title: "Element"
     description: "Element"
     views: "Element"
@@ -39,6 +40,7 @@ class Video:
         video.uploaded = _decode_date_yt(entry["upload_date"])
         video.width = entry["width"]
         video.height = entry["height"]
+        video.ext = None
         video.title = Element.new(video, entry["title"])
         video.description = Element.new(video, entry["description"])
         video.views = Element.new(video, entry["view_count"])
@@ -75,14 +77,12 @@ class Video:
         # Runtime-only
         self.known_not_deleted = True
 
-    def downloaded(self, ldir: list) -> bool:
+    def downloaded(self) -> bool:
         """Checks if this video has been downloaded"""
-        # Try to find id in videos
-        for file in ldir:
-            if fnmatch(file, f"{self.id}.mp4"):
+        videos = self.channel.path / "videos"
+        for file in videos.iterdir():
+            if file.stem == self.id and file.suffix != ".part":
                 return True
-
-        # No matches
         return False
 
     def updated(self) -> bool:
@@ -115,6 +115,7 @@ class Video:
         video.uploaded = datetime.fromisoformat(encoded["uploaded"])
         video.width = encoded["width"]
         video.height = encoded["height"]
+        # video.ext = encoded["ext"] # TODO: uncomment for 0.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
         video.title = Element._from_dict(encoded["title"], video)
         video.description = Element._from_dict(encoded["description"], video)
         video.views = Element._from_dict(encoded["views"], video)
@@ -136,6 +137,7 @@ class Video:
             "uploaded": self.uploaded.isoformat(),
             "width": self.width,
             "height": self.height,
+            # "ext": self.ext, # TODO: uncomment for 0.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
             "title": self.title._to_dict(),
             "description": self.description._to_dict(),
             "views": self.views._to_dict(),

--- a/yark/video.py
+++ b/yark/video.py
@@ -21,7 +21,6 @@ class Video:
     uploaded: datetime
     width: int
     height: int
-    ext: str
     title: "Element"
     description: "Element"
     views: "Element"
@@ -40,7 +39,6 @@ class Video:
         video.uploaded = _decode_date_yt(entry["upload_date"])
         video.width = entry["width"]
         video.height = entry["height"]
-        video.ext = None
         video.title = Element.new(video, entry["title"])
         video.description = Element.new(video, entry["description"])
         video.views = Element.new(video, entry["view_count"])
@@ -77,13 +75,17 @@ class Video:
         # Runtime-only
         self.known_not_deleted = True
 
-    def downloaded(self) -> bool:
-        """Checks if this video has been downloaded"""
+    def filename(self) -> Optional[str]:
+        """Returns the filename for the downloaded video, if any"""
         videos = self.channel.path / "videos"
         for file in videos.iterdir():
             if file.stem == self.id and file.suffix != ".part":
-                return True
-        return False
+                return file.name
+        return None
+
+    def downloaded(self) -> bool:
+        """Checks if this video has been downloaded"""
+        return self.filename() is not None
 
     def updated(self) -> bool:
         """Checks if this video's title or description or deleted status have been ever updated"""
@@ -115,7 +117,6 @@ class Video:
         video.uploaded = datetime.fromisoformat(encoded["uploaded"])
         video.width = encoded["width"]
         video.height = encoded["height"]
-        # video.ext = encoded["ext"] # TODO: uncomment for 1.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
         video.title = Element._from_dict(encoded["title"], video)
         video.description = Element._from_dict(encoded["description"], video)
         video.views = Element._from_dict(encoded["views"], video)
@@ -137,7 +138,6 @@ class Video:
             "uploaded": self.uploaded.isoformat(),
             "width": self.width,
             "height": self.height,
-            # "ext": self.ext, # TODO: uncomment for 1.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
             "title": self.title._to_dict(),
             "description": self.description._to_dict(),
             "views": self.views._to_dict(),

--- a/yark/video.py
+++ b/yark/video.py
@@ -115,7 +115,7 @@ class Video:
         video.uploaded = datetime.fromisoformat(encoded["uploaded"])
         video.width = encoded["width"]
         video.height = encoded["height"]
-        # video.ext = encoded["ext"] # TODO: uncomment for 0.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
+        # video.ext = encoded["ext"] # TODO: uncomment for 1.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
         video.title = Element._from_dict(encoded["title"], video)
         video.description = Element._from_dict(encoded["description"], video)
         video.views = Element._from_dict(encoded["views"], video)
@@ -137,7 +137,7 @@ class Video:
             "uploaded": self.uploaded.isoformat(),
             "width": self.width,
             "height": self.height,
-            # "ext": self.ext, # TODO: uncomment for 0.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
+            # "ext": self.ext, # TODO: uncomment for 1.3, breaking change to help #55 <https://github.com/Owez/yark/issues/55> for archive format 4
             "title": self.title._to_dict(),
             "description": self.description._to_dict(),
             "views": self.views._to_dict(),

--- a/yark/viewer.py
+++ b/yark/viewer.py
@@ -88,6 +88,7 @@ def video(name, kind, id):
             return render_template(
                 "video.html",
                 title=title,
+                name=name,
                 video=video,
                 views_data=views_data,
                 likes_data=likes_data,
@@ -173,10 +174,16 @@ def video(name, kind, id):
         return redirect(url_for("routes.index", error=f"Internal server error:\n{e}"))
 
 
-@routes.route("/archive/<path:target>")
-def archive(target):
-    """Serves archive files"""
-    return send_from_directory(os.getcwd(), target)
+@routes.route("/archive/<name>/video/<file>")
+def archive_video(name, file):
+    """Serves video file using it's filename (id + ext)"""
+    return send_from_directory(os.getcwd(), f"{name}/videos/{file}")
+
+
+@routes.route("/archive/<name>/thumbnail/<id>")
+def archive_thumbnail(name, id):
+    """Serves thumbnail file using it's id"""
+    return send_from_directory(os.getcwd(), f"{name}/thumbnails/{id}.webp")
 
 
 def viewer() -> Flask:


### PR DESCRIPTION
- This skips undownloadable videos if FFmpeg isn't installed on a users machine and they try to download a video which has a broken format 22
- The new skip message comes with a warning message telling users to download FFmpeg, which is now also suggested on the README
- Faster thumbnail and video fetching has been implemented by the feel of it in development
- Support for webm and all other video types

Closes #55, #59