### PR TITLE
Standardize archived videos to webm/mp4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The archive format itself is simple and consists of a directory-based structure 
   - `yark.bak` – Backup archive file to protect against data damage
   - `videos/` – Directory containing all known videos
     - `[id].*` – Files containing video data for YouTube videos
-  - `images/` – Directory containing all known images (e.g. thumbnails, icons)
+  - `images/` – Directory containing all known images (e.g., thumbnails, icons)
     - `[hash].png` – Files containing images with their BLAKE2 hash
 
 It's best to take a few minutes to familiarize yourself with your archive by looking at files which look interesting to you in it, everything is quite readable.

--- a/yark/__init__.py
+++ b/yark/__init__.py
@@ -20,11 +20,11 @@ Commonly-used
 Exceptions
 ----------
 - `ArchiveNotFoundException`
+- `ArchiveStructureException`
 - `VideoNotFoundException`
 - `NoteNotFoundException`
 - `TimestampException`
 - `FileNotFoundException`
-- `ConversionException`
 
 Beware that using Yark as a library is currently experimental and breaking changes here are not tracked!
 """
@@ -42,9 +42,9 @@ from .video import (
 from .viewer import viewer
 from .errors import (
     ArchiveNotFoundException,
+    ArchiveStructureException,
     VideoNotFoundException,
     NoteNotFoundException,
     TimestampException,
-    FileNotFoundException,
     ConversionException,
 )

--- a/yark/__init__.py
+++ b/yark/__init__.py
@@ -16,10 +16,15 @@ Commonly-used
     - `CommentAuthor`
     - `Image`
 - `viewer()`
+
+Exceptions
+----------
 - `ArchiveNotFoundException`
 - `VideoNotFoundException`
 - `NoteNotFoundException`
 - `TimestampException`
+- `FileNotFoundException`
+- `ConversionException`
 
 Beware that using Yark as a library is currently experimental and breaking changes here are not tracked!
 """
@@ -40,4 +45,6 @@ from .errors import (
     VideoNotFoundException,
     NoteNotFoundException,
     TimestampException,
+    FileNotFoundException,
+    ConversionException,
 )

--- a/yark/archive.py
+++ b/yark/archive.py
@@ -13,6 +13,7 @@ from .errors import ArchiveNotFoundException, _err_msg, VideoNotFoundException
 from .video import Video, Element, CommentAuthor
 from typing import Optional
 from .config import Config
+from .converter import Converter
 
 ARCHIVE_COMPAT = 4
 """
@@ -211,6 +212,7 @@ class Archive:
         settings = self._dl_settings(config)
 
         # Retry downloading 5 times in total for all videos
+        anything_downloaded = True
         for i in range(5):
             # Try to curate a list and download videos on it
             try:
@@ -219,6 +221,7 @@ class Archive:
 
                 # Stop if there's nothing to download
                 if len(not_downloaded) == 0:
+                    anything_downloaded = False
                     break
 
                 # Print curated if this is the first time
@@ -239,6 +242,11 @@ class Archive:
 
                 # Report error
                 _err_dl("videos", exception, i != 4)
+
+        # End by converting any downloaded but unsupported video file formats
+        if anything_downloaded:
+            converter = Converter(self.path / "videos")
+            converter.all()
 
     def _dl_settings(self, config: Config) -> dict:
         """Generates customized yt-dlp settings from `config` passed in"""
@@ -425,6 +433,7 @@ class Archive:
         deletion_bucket: list[Path] = []
 
         # Scan through and find part files
+        # NOTE: can this be improved with a set and 2x path.glob()?
         videos = self.path / "videos"
         for file in videos.iterdir():
             if file.suffix == ".part" or file.suffix == ".ytdl":
@@ -613,6 +622,10 @@ def _migrate_archive(
                     f"Couldn't rename {archive_name}/thumbnails directory to {archive_name}/images, please manually rename to continue!"
                 )
                 sys.exit(1)
+
+            # Convert unsupported formats, because of #75 <https://github.com/Owez/yark/issues/75>
+            converter = Converter(path / "videos")
+            converter.all()
 
         # Unknown version
         else:

--- a/yark/converter.py
+++ b/yark/converter.py
@@ -11,35 +11,35 @@ class Converter:
         _ensure_dir(path_videos)
         self.path_videos = path_videos
 
-    def mkv(self, video_name: str):
+    def all(self):
+        """Goes through the videos directory given and converts all videos we can, e.g. mkv to mp4"""
+        # Convert mkv videos
+        for path in self.path_videos.glob("*.mkv"):
+            self.convert_mkv(path)
+
+    def convert_mkv(self, path: Path):
         """Converts mkv at path to a fully-supported mp4 video"""
         # Check everything exists
-        self._ensure(video_name)
+        self._ensure(path)
 
         # Generate/resolve paths
-        mkv_path, mp4_path = self._resolve(video_name, ".mp4")
+        mkv_path, mp4_path = self._resolve(path, ".mp4")
 
         # Tell ffmpeg to convert
         _ffmpeg_run(["-y", "-i", mkv_path, "-codec", "copy", mp4_path])
 
-    def delete(self):
-        """Deletes the current path after conversion"""
-        self.path.unlink()
+        # Delete the original path
+        path.unlink()
 
-    def _ensure(self, video_name: str):
+    def _ensure(self, path: Path):
         """Ensures that everything is ready to go, might error out or raise `FileNotFoundException` exception"""
         _ensure_ffmpeg()
         _ensure_dir(self.path_videos)
-        _ensure_file(self._path_video_name(video_name))
+        _ensure_file(path)
 
-    def _resolve(self, video_name: str, new_suffix: str) -> tuple[str, str]:
+    def _resolve(self, path: Path, new_suffix: str) -> tuple[str, str]:
         """Resolves path and creates a new one with the suffix replaced by the new suffix"""
-        path = self._path_video_name(video_name)
         return str(path.resolve()), str(path.with_suffix(new_suffix).resolve())
-
-    def _path_video_name(self, video_name: str) -> Path:
-        """Generates path to inputted video name from the baseline converter path"""
-        return self.path_videos / video_name
 
 
 def _ffmpeg_installed() -> bool:

--- a/yark/converter.py
+++ b/yark/converter.py
@@ -1,0 +1,90 @@
+"""Video conversion for formats not supported by the HTML `<video>` tag, our low bar"""
+
+from pathlib import Path
+from .errors import _err_msg, FileNotFoundException, ConversionException
+import subprocess
+import sys
+
+
+class Converter:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def mkv(self):
+        """Converts mkv at path to a fully-supported mp4 video"""
+        # Check everything exists
+        self._ensure()
+
+        # Generate/resolve paths
+        mkv_path, mp4_path = self._resolve(".mp4")
+
+        # Tell ffmpeg to convert
+        _ffmpeg_run(["-y", "-i", mkv_path, "-codec", "copy", mp4_path])
+
+    def delete(self):
+        """Deletes the current path after conversion"""
+        self.path.unlink()
+
+    def _ensure(self):
+        """Ensures that everything is ready to go, might error out or raise `FileNotFoundException` exception"""
+        _ensure_ffmpeg()
+        _ensure_file(self.path)
+
+    def _resolve(self, new_suffix: str) -> tuple[Path, Path]:
+        """Resolves path and creates a new one with the suffix replaced by the new suffix"""
+        return self.path.resolve(), self.path.with_suffix(new_suffix).resolve()
+
+
+def _ffmpeg_installed() -> bool:
+    """Returns if ffmpeg is installed and accessible by running `ffmpeg` as a process like yt-dlp"""
+    try:
+        _ffmpeg_run(["--help"])
+        return True
+    except:
+        return False
+
+
+def _ffmpeg_run(args: list[str]):
+    """Runs an ffmpeg command with the `args` provided, raises `ConversionException` exception if command failed"""
+    # Add ffmpeg to start of args
+    process_args = ["ffmpeg"]
+    process_args.extend(args)
+
+    # Run the process for ffmpeg
+    process = subprocess.Popen(
+        process_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+
+    # Poll for return code meaning it's finished
+    while True:
+        # Poll for the status code (if any)
+        poll = process.poll()
+
+        # Command finished
+        if poll is not None:
+            # Error whilst running
+            if poll == 1:
+                stderr = (
+                    process.stderr.read().decode()
+                    if process.stderr is not None
+                    else "Unknown error"
+                )
+                raise ConversionException(stderr)
+
+            # Command completed successfully
+            break
+
+
+def _ensure_file(path: Path):
+    """Ensures that the `path` inputted exists and isn't a dir or raises the `FileNotFoundException` exception"""
+    if not path.exists() or path.is_dir():
+        raise FileNotFoundException(path)
+
+
+def _ensure_ffmpeg():
+    """Errors out of the application if ffmpeg is not installed"""
+    if not _ffmpeg_installed():
+        _err_msg(
+            "FFmpeg is needed to convert a video but it wasn't found, please install it!"
+        )
+        sys.exit(1)

--- a/yark/converter.py
+++ b/yark/converter.py
@@ -11,14 +11,22 @@ class Converter:
         _ensure_dir(path_videos)
         self.path_videos = path_videos
 
-    def all(self):
+    def run(self):
         """Goes through the videos directory given and converts all videos we can, e.g. mkv to mp4"""
         # Convert mkv videos
         for path in self.path_videos.glob("*.mkv"):
-            self.convert_mkv(path)
+            self._convert_copy_codec(path)
 
-    def convert_mkv(self, path: Path):
-        """Converts mkv at path to a fully-supported mp4 video"""
+        # Convert flv videos
+        for path in self.path_videos.glob("*.flv"):
+            self._convert_copy_codec(path)
+
+        # Convert 3gp videos
+        for path in self.path_videos.glob("*.3gp"):
+            self._convert_copy_codec(path)
+
+    def _convert_copy_codec(self, path: Path):
+        """Runs complete conversion process for ffmpeg commands which can copy codecs"""
         # Check everything exists
         self._ensure(path)
 

--- a/yark/converter.py
+++ b/yark/converter.py
@@ -17,10 +17,6 @@ class Converter:
         for path in self.path_videos.glob("*.mkv"):
             self._convert_copy_codec(path)
 
-        # Convert flv videos
-        for path in self.path_videos.glob("*.flv"):
-            self._convert_copy_codec(path)
-
         # Convert 3gp videos
         for path in self.path_videos.glob("*.3gp"):
             self._convert_copy_codec(path)

--- a/yark/errors.py
+++ b/yark/errors.py
@@ -2,6 +2,7 @@
 
 from colorama import Style, Fore
 import sys
+from pathlib import Path
 
 
 class ArchiveNotFoundException(Exception):
@@ -32,12 +33,12 @@ class TimestampException(Exception):
         super().__init__(*args)
 
 
-class FileNotFoundException(Exception):
-    """File inside of an archive (e.g., image/video) for a required operation couldn't be found"""
+class ArchiveStructureException(Exception):
+    """Directory or file inside of an archive for a required operation couldn't be found when it should've"""
 
-    def __init__(self, file, *args: object) -> None:
+    def __init__(self, path: Path, *args: object) -> None:
         super().__init__(*args)
-        self.file = file
+        self.path = path
 
 
 class ConversionException(Exception):

--- a/yark/errors.py
+++ b/yark/errors.py
@@ -32,6 +32,26 @@ class TimestampException(Exception):
         super().__init__(*args)
 
 
+class FileNotFoundException(Exception):
+    """File inside of an archive (e.g., image/video) for a required operation couldn't be found"""
+
+    def __init__(self, file, *args: object) -> None:
+        super().__init__(*args)
+        self.file = file
+
+
+class ConversionException(Exception):
+    """Couldn't convert a video file format to a different one because of an error with FFmpeg"""
+
+    def __init__(
+        self,
+        stderr: str,
+        *args: object,
+    ) -> None:
+        super().__init__(*args)
+        self.stderr = stderr
+
+
 def _err_msg(msg: str, report_msg: bool = False):
     """Provides a red-coloured error message to the user in the STDERR pipe"""
     msg = (


### PR DESCRIPTION
Adds a converter class which converts all unsupported video filetypes to supported ones (depending on which is the fastest conversion). Currently this converts `.mkv` videos to `.mp4` videos with a lot of room for expansion. This checks the videos directory if a video was downloaded and is ran for archive version v3 to v4 migration.