### PR TITLE
Add `--cookies` option for authenticating requests

### DIFF
--- a/yark/archiver/config.py
+++ b/yark/archiver/config.py
@@ -46,6 +46,7 @@ class Config:
     comments: bool = False
     format: Optional[str] = None
     proxy: Optional[str] = None
+    cookies: Optional[str] = None
     bind_host: Optional[str] = None
     bind_port: int = 7667
     headless: bool = False
@@ -99,6 +100,10 @@ class Config:
         if self.proxy is not None:
             settings["proxy"] = self.proxy
 
+        # Cookies file to allow, for example, archiving private playlists
+        if self.cookies is not None:
+            settings["cookiefile"] = self.cookies
+
         # Return
         return settings
 
@@ -117,6 +122,10 @@ class Config:
         # Custom yt-dlp proxy
         if self.proxy is not None:
             settings["proxy"] = self.proxy
+
+        # Cookies file to allow, for example, archiving private playlists
+        if self.cookies is not None:
+            settings["cookiefile"] = self.cookies
 
         # Return
         return settings

--- a/yark/cli.py
+++ b/yark/cli.py
@@ -98,7 +98,7 @@ def _cli() -> None:
         if len(args) > 2:
 
             def parse_value(config_arg: str) -> str:
-                return config_arg.split("=")[1]
+                return config_arg.split("=", 1)[1]
 
             def parse_maximum_int(config_arg: str) -> int:
                 """Tries to parse a maximum integer input"""

--- a/yark/cli.py
+++ b/yark/cli.py
@@ -146,6 +146,9 @@ def _cli() -> None:
                 elif config_arg.startswith("--proxy="):
                     config.proxy = parse_value(config_arg)
 
+                elif config_arg.startswith("--cookies="):
+                    config.cookies = parse_value(config_arg)
+
                 # Unknown argument
                 else:
                     print(HELP, file=sys.stderr)
@@ -215,9 +218,9 @@ def _cli() -> None:
             msg = f"Starting archive at {url} address"
             if archive_name is not None:
                 msg += f" for {archive_name} archive"
-            
+
             print(msg)
-            
+
             app = viewer()
             threading.Thread(target=lambda: app.run(port=config.bind_port, host=config.bind_host)).run()
 
@@ -271,8 +274,8 @@ def _cli() -> None:
                     # If config_idx is 1 (first parameter could be name of archive)
                     if config_idx == 1:
                         archive_name = config_arg
-                    
-                    # If config_idx is not 1 
+
+                    # If config_idx is not 1
                     # (not the first parameter, wasn't parsed earlier, must be an invalid parameter)
                     else:
                         print(HELP, file=sys.stderr)


### PR DESCRIPTION
Hi, added a new flag, intended to solve the issue reported in #112. 😃 

Added a `--cookies` option to allow passing a filepath containing cookies and perform authentication with it.

The file can easily be generated by running a command like:
```shell
yt-dlp --cookies cookies.txt --cookies-from-browser chrome
```

And then used in yark like:
```shell
yark refresh archive-name --cookies=cookies.txt
```

An alternative would be to expose `--cookies-from-browser` in yark too. But instead of passing that each time we call yt-dlp, we could call it once just to generate the text file on a temp folder and then use that temp file. The only thing holding me back from that approach is worrying about temporary files left over in the disk with the list of all cookies of the browser, but I guess that's not too bad and there are ways to mitigate it a bit. 😄 

PS: Sorry about the random edited lines, I think it was my editor's trim white space and add new line at the end of the file automatically on save. If you want I can do a commit to revert those changes.