### PR TITLE
Break metadata downloading into smaller steps for more resiliency with large channels

### DIFF
--- a/yark/channel.py
+++ b/yark/channel.py
@@ -231,7 +231,7 @@ class Channel:
             # first extract the "flat" metadata, which does not download the metadata for all the videos
             for i in range(3):
                 try:
-                    res = YoutubeDL(params=settings).extract_info(self.url, download=False)
+                    res: dict[str, Any] = ydl.extract_info(self.url, download=False)
                     break
                 except Exception as exception:
                     # Report error

--- a/yark/channel.py
+++ b/yark/channel.py
@@ -247,35 +247,60 @@ class Channel:
                         )  # TODO: compat with loading bar
 
             # go through the "flat" metadata and download the metadata for each video
-            for index in range(len(res['entries'])):
-                url = res['entries'][index]['url'] 
-                for i in range(3):
-                    try:
-                        entry = ydl.extract_info(url, download=False)
-                        # if no formats were retrieved, it could be a pending livestream, or the downloader may be failing
-                        # when retrieving hundreds of videos, they begin failing after several hundred (token expiring?)
-                        # opening a new downloader can solve this
-                        if len(entry['formats']) == 0:
-                            ydl = YoutubeDL(settings)
+            for index in range(len(res["entries"])):
+                if res["entries"][index]["_type"] == "playlist":
+                    playlist = res["entries"][index]
+                    for list_index in range(len(playlist["entries"])):
+                        url = playlist["entries"][list_index]["url"]
+                        for i in range(3):
+                            try:
+                                entry = ydl.extract_info(url, download=False)
+                                if len(entry["formats"]) == 0:
+                                    ydl = YoutubeDL(settings)
+                                    entry = ydl.extract_info(url, download=False)
+
+                                playlist["entries"][list_index] = entry
+                                break
+                            except Exception as exception:
+                                # Report error
+                                retrying = i != 2
+                                _err_dl("metadata", exception, retrying)
+
+                                # Print retrying message
+                                if retrying:
+                                    print(
+                                        Style.DIM
+                                        + f"  • Retrying metadata download.."
+                                        + Style.RESET_ALL
+                                    )  # TODO: compat with loading bar
+
+
+                elif res["entries"][index]["_type"] == "url":
+                    url = res["entries"][index]["url"] 
+                    for i in range(3):
+                        try:
                             entry = ydl.extract_info(url, download=False)
+                            # if video didn't download formats, open a new downloader and try again
+                            if len(entry["formats"]) == 0:
+                                ydl = YoutubeDL(settings)
+                                entry = ydl.extract_info(url, download=False)
 
-                        res['entries'][index] = entry
-                        break
-                    except Exception as exception:
-                        # Report error
-                        retrying = i != 2
-                        _err_dl("metadata", exception, retrying)
+                            res["entries"][index] = entry
+                            break
+                        except Exception as exception:
+                            # Report error
+                            retrying = i != 2
+                            _err_dl("metadata", exception, retrying)
 
-                        # Print retrying message
-                        if retrying:
-                            print(
-                                Style.DIM
-                                + f"  • Retrying metadata download.."
-                                + Style.RESET_ALL
-                            )  # TODO: compat with loading bar
+                            # Print retrying message
+                            if retrying:
+                                print(
+                                    Style.DIM
+                                    + f"  • Retrying metadata download.."
+                                    + Style.RESET_ALL
+                                )  # TODO: compat with loading bar
 
             return res
-
 
     def _parse_metadata(self, res: dict[str, Any]):
         """Parses entirety of downloaded metadata"""


### PR DESCRIPTION
Thanks for making Yark! This PR solves an issue I was having that sounds like #71

The issue was a large playlist with ~600 videos wasn't fully downloading. It would only download around 300 videos, and then on subsequent runs of `yark refresh`, it would show several videos as either being deleted, or as being added, right around that limit of where it stopped downloading. It was not storing the metadata of every video, and how many it would download was fluctuating a little bit on each run.

It seems this happens when running `YoutubeDL().extract_info(url, download=False)` on a playlist or channel with too many videos. It can download the metadata of several hundred videos, but then will stop getting complete metadata, and does not get the `formats` metadata. Then, in `_parse_metadata_videos_comp`, since the entry has no `formats`, it is skipped, since it is believed to be a livestream or other edge case (see #62).

To fix this, we can first download the metadata "flat" via `YoutubeDL(params={'extract_flat':True}).extract_info`, meaning `YoutubeDL` does not follow the URLs of the videos to download their metadata, it simply gets their URLs (and a little bit of metadata) . We can then download the full metadata of the videos one by one, and if they fail, we can make a new `YoutubeDL()` object and try again, which seems to solve the problem for another several hundred videos until a new `YoutubeDL()` is needed. I don't know exactly why this works, maybe something to do with expiring tokens?

The detection for the metadata download failure is checking if the `formats` key of the entry is empty. There is probably a better way to check this, and I think that YoutubeDL may be generating warnings that are getting swallowed by `VideoLogger`.

The `entries` in the result of `extract_info` can either be a playlist (with its own `entries`), or a "url" entry. I was lazy here, and just copied your strategy of trying 3 times and catching exceptions whenever calling `extract_info`, but I'm not sure how much we're getting out of it when using it for downloading the metadata of a single video. It may make sense to pull the logic of downloading one video's metadata into its own function, but I wasn't sure if we should be passing the `YoutubeDL` object to that function for it to use, or if it would be fine to create a new `YoutubeDL` every time.